### PR TITLE
fix: 修复移动端 SparkChart 不显示的问题

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -138,11 +138,13 @@ const Page = () => {
 
   return (
     <>
-      <header className="w-full pt-6 px-6 flex items-center md:h-[80px] md:pt-0">
-        <Logo />
-        <FinanceTotal />
-        <div className="flex-1" />
-        <div className="flex gap-4 items-center">
+      <header className="w-full pt-6 px-3 md:px-6 flex flex-wrap items-center gap-x-3 gap-y-3 md:h-[80px] md:flex-nowrap md:pt-0">
+        <Logo className="shrink-0" />
+        <div className="order-3 w-full md:order-none md:w-auto md:flex-1 md:min-w-0 md:ml-1">
+          <FinanceTotal />
+        </div>
+        <div className="flex-1 md:hidden min-w-0" />
+        <div className="flex gap-2 md:gap-4 items-center shrink-0 ml-auto md:ml-0">
           <GroupSwitcher />
           <ExchangeRateSettings />
           <PasswordSettings />

--- a/components/financeTotal.tsx
+++ b/components/financeTotal.tsx
@@ -118,32 +118,30 @@ export default function FinanceTotal() {
   if (!displayAmount) return null;
 
   return (
-    <>
-      <Tooltip content={showAll ? t("switchToGroup") : t("switchToAll")}>
-        <span
-          className="hidden md:flex items-center gap-2 cursor-pointer select-none"
-          style={{ fontFamily: "Rajdhani" }}
-          onClick={() => setShowAll((v) => !v)}
-        >
-          <span className="text-primary text-xl md:text-4xl font-bold">
-            <NumberFlow
-              value={displayAmount}
-              prefix={currencyMap[defaultCurrency]?.symbol}
-              format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
-            />
-          </span>
+    <Tooltip content={showAll ? t("switchToGroup") : t("switchToAll")}>
+      <div
+        className="flex items-center gap-2 cursor-pointer select-none min-w-0"
+        style={{ fontFamily: "Rajdhani" }}
+        onClick={() => setShowAll((v) => !v)}
+      >
+        <span className="text-primary text-xl md:text-4xl font-bold shrink-0">
+          <NumberFlow
+            value={displayAmount}
+            prefix={currencyMap[defaultCurrency]?.symbol}
+            format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+          />
         </span>
-      </Tooltip>
-      {displayTrend && (
-        <SparkLineChart
-          data={displayTrendData}
-          index="date"
-          categories={["total"]}
-          colors={["primary"]}
-          autoMinValue
-          className="py-2 ml-4"
-        />
-      )}
-    </>
+        {displayTrend && (
+          <SparkLineChart
+            data={displayTrendData}
+            index="date"
+            categories={["total"]}
+            colors={["primary"]}
+            autoMinValue
+            className="py-2 shrink-0"
+          />
+        )}
+      </div>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

移动端 header 空间不足，SparkLineChart 被 flex 布局挤压，导致趋势小图无法正常显示。同时总金额使用了 `hidden md:flex`，在移动端也被隐藏。

## 修改

1. **`components/financeTotal.tsx`**
   - 将总金额与 SparkLineChart 合并到同一个 flex 容器中，在所有断点下都可见
   - 为 SparkLineChart 添加 `shrink-0`，防止在 flex 布局中被压缩到 0 宽度

2. **`app/page.tsx`**
   - 调整 header 为移动端换行布局：第一行显示 Logo 与操作按钮，第二行全宽显示 FinanceTotal
   - 桌面端保持原有单行布局

## 效果

- 移动端：Logo + 操作按钮在第一行，总金额与趋势小图在第二行完整展示
- 桌面端：布局与交互保持不变
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1b3e80f-bd64-4c33-9b7c-452e2ae0790f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1b3e80f-bd64-4c33-9b7c-452e2ae0790f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

