### PR TITLE
Sync English README with Chinese README updates

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -15,9 +15,9 @@
   <img alt="fibofinance demo" src="./public/en/demo.png">
 </p>
 
-[English](./README.md) | [简体中文](./README_ZH.md)
+[English](./README_EN.md) | [简体中文](./README.md)
 
-FiboFinance is a lightweight, self-hosted asset tracking app: record assets, view trends and allocation, and get AI analysis when needed.
+FiboFinance is a lightweight, self-hosted asset tracking app that tracks asset changes by recording current asset values, moving beyond traditional bookkeeping.
 
 ## Demo
 
@@ -25,11 +25,11 @@ https://fibofinance.cn
 
 ## Highlights
 
-- Self-hosted, data-secure, and password-protected
-- Supports group management
-- Multi-currency support with custom exchange rates (silver, gold, and similar assets can be recorded by gram and automatically converted to CNY)
-- Supports trend charts, allocation pie charts, and history records
-- Supports AI analysis
+- Easy deployment, data security, and password protection
+- Personal and family asset grouping without mixing assets
+- Multi-currency support with custom exchange rates (silver, gold, and similar assets can be recorded by gram)
+- Asset trend charts and flexible comparison of asset changes
+- Configure an AI key for asset allocation recommendations
 
 ## Deployment
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Syncs `README_EN.md` with recent changes in `README.md`.

## Changes

- **Language links**: Fix switcher to point to `README_EN.md` and `README.md` (was incorrectly linking to `README.md` / non-existent `README_ZH.md`)
- **Description**: Reflect value-tracking approach instead of traditional bookkeeping
- **Highlights**: Align with Chinese version:
  - Easy deployment (was "self-hosted")
  - Personal/family asset grouping without mixing assets
  - Multi-currency with gram-based precious metals (removed auto CNY conversion note)
  - Asset trend charts and flexible comparison (removed pie chart/history wording)
  - AI key for allocation recommendations (was generic "AI analysis")
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87e3e1fb-bad0-43fb-9f97-53899a47c9aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87e3e1fb-bad0-43fb-9f97-53899a47c9aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

